### PR TITLE
Change SASS property-sort-order to concentric

### DIFF
--- a/lib/codeStyles/Sass/sasslint/.sass-lint.yaml
+++ b/lib/codeStyles/Sass/sasslint/.sass-lint.yaml
@@ -46,7 +46,9 @@ rules:
     no-trailing-whitespace: 2
     no-trailing-zero: 1
     one-declaration-per-line: 2
-    property-sort-order: 1
+    property-sort-order:
+        - 2
+        - order: 'concentric'
     quotes: 2
     shorthand-values: 1
     space-after-bang: 2


### PR DESCRIPTION
Sorting sass on alphabetical order was not helping us at all, where concentric ordering does give us significant benefits.
https://rhodesmill.org/brandon/2011/concentric-css/